### PR TITLE
Fix The Spelling Error For The Log

### DIFF
--- a/src/main/java/com/example/Application.java
+++ b/src/main/java/com/example/Application.java
@@ -19,7 +19,7 @@ public class Application {
     public void init()
     {
         Logger log = LoggerFactory.getLogger(Application.class);
-        log.info("Java app starte");
+        log.info("Java app start");
     }
 
     public String getStatus() {


### PR DESCRIPTION
The word "start" was spelled incorrectly